### PR TITLE
Fix Windows path encoding for project directory lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -882,7 +882,11 @@ func runDoctor() {
 	fmt.Println()
 
 	allGood := true
-	home := os.Getenv("HOME")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Println("  [!!] Could not determine home directory")
+		return
+	}
 
 	// Check Claude Code installation
 	fmt.Println("Claude Code:")
@@ -919,7 +923,7 @@ func runDoctor() {
 
 	cwd, _ := os.Getwd()
 	absPath, _ := filepath.Abs(cwd)
-	encoded := strings.ReplaceAll(absPath, "/", "-")
+	encoded := encodePath(absPath)
 	projectDir := filepath.Join(projectsDir, encoded)
 
 	fmt.Printf("  Path: %s\n", cwd)


### PR DESCRIPTION
# Summary

  - Fix path encoding to match Claude Code's folder naming convention on Windows (C:\Users\foo\project →
  C--Users-foo-project)
  - Replace os.Getenv("HOME") with os.UserHomeDir() for reliable home directory resolution on Windows

 # Problem

  On Windows, cq fails to find Claude Code conversations because:

  1. Path encoding only replaced / with -, which is a no-op on Windows paths that use \ backslashes. Claude Code
  encodes C:\Users\john\Documents\claude-quest as C--Users-john-Documents-claude-quest, but cq was producing
  C:\Users\john\Documents\claude-quest unchanged.
  2. os.Getenv("HOME") returns empty on Windows (PowerShell/CMD don't set HOME), so the ~/.claude/projects/ lookup
  path was broken.

 # Fix

  Added an encodePath() helper that normalizes paths cross-platform:
  - filepath.ToSlash() converts \ → / (no-op on Unix)
  - Replace : → - (handles drive letter; no-op on Unix since no colons in paths)
  - Replace / → - (existing behavior)

  No behavior change on macOS/Linux.

  # Test plan

  - Code review: encodePath output matches Claude Code's encoding on both platforms
  - Windows: cq finds conversations for current project
  - Windows: cq doctor shows correct encoded path
  - macOS/Linux: no regression (identical encoding output)