### PR TITLE
fix: match Claude Code's exact project-path sanitizer (handles non-ASCII, _, +, truncation)

### DIFF
--- a/main.go
+++ b/main.go
@@ -928,7 +928,7 @@ func runDoctor() {
 	cwd, _ := os.Getwd()
 	absPath, _ := filepath.Abs(cwd)
 	encoded := encodeProjectPath(absPath)
-	projectDir := filepath.Join(projectsDir, encoded)
+	projectDir := resolveProjectDir(projectsDir, encoded)
 
 	fmt.Printf("  Path: %s\n", cwd)
 	fmt.Printf("  Encoded: %s\n", encoded)

--- a/watcher.go
+++ b/watcher.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -172,7 +173,7 @@ func (w *Watcher) FindProjectConversation(projectDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get Claude config directory: %w", err)
 	}
-	claudeProjectDir := filepath.Join(configDir, "projects", encoded)
+	claudeProjectDir := resolveProjectDir(filepath.Join(configDir, "projects"), encoded)
 	w.ProjectDir = claudeProjectDir
 
 	// Check if project directory exists
@@ -763,15 +764,87 @@ func claudeConfigDir() (string, error) {
 	return filepath.Join(home, ".claude"), nil
 }
 
-// encodeProjectPath converts an absolute path to Claude's project directory name format.
-// Claude Code replaces /, \, :, ., and spaces with - when naming project directories.
+// encodeProjectPath converts an absolute path to Claude's project directory
+// name. Mirrors Claude Code's `pM` function: every char outside [a-zA-Z0-9]
+// becomes '-', and results longer than 200 chars are truncated and suffixed
+// with a base36 hash of the original path so distinct long paths never
+// collide. Case is preserved, so two invocations whose cwd differs only in
+// drive-letter casing produce different folder names — callers should pair
+// this with resolveProjectDir for case-insensitive disk lookup.
 func encodeProjectPath(absPath string) string {
-	encoded := strings.ReplaceAll(absPath, "\\", "-")
-	encoded = strings.ReplaceAll(encoded, ":", "-")
-	encoded = strings.ReplaceAll(encoded, "/", "-")
-	encoded = strings.ReplaceAll(encoded, ".", "-")
-	encoded = strings.ReplaceAll(encoded, " ", "-")
-	return encoded
+	var b strings.Builder
+	b.Grow(len(absPath))
+	for _, r := range absPath {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		// Match JS String.replace(/[^a-zA-Z0-9]/g, "-") behavior: each UTF-16
+		// code unit becomes one '-'. BMP runes are one code unit; non-BMP
+		// (e.g. emoji) are surrogate pairs and produce two dashes.
+		if r > 0xFFFF {
+			b.WriteString("--")
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	encoded := b.String()
+	if len(encoded) <= projectPathMaxLen {
+		return encoded
+	}
+	return encoded[:projectPathMaxLen] + "-" + projectPathHashSuffix(absPath)
+}
+
+const projectPathMaxLen = 200
+
+// projectPathHashSuffix replicates Claude Code's hash: a 32-bit signed
+// djb2-style accumulator over UTF-16 code units, then Math.abs(...).toString(36).
+func projectPathHashSuffix(s string) string {
+	var h int32
+	for _, r := range s {
+		if r > 0xFFFF {
+			// JS iterates UTF-16 code units, so a non-BMP rune contributes
+			// its surrogate pair, not the raw code point.
+			r -= 0x10000
+			high := int32(0xD800 + (r >> 10))
+			low := int32(0xDC00 + (r & 0x3FF))
+			h = (h<<5 - h + high) | 0
+			h = (h<<5 - h + low) | 0
+			continue
+		}
+		h = (h<<5 - h + int32(r)) | 0
+	}
+	abs := int64(h)
+	if abs < 0 {
+		abs = -abs
+	}
+	return strconv.FormatInt(abs, 36)
+}
+
+// resolveProjectDir returns the actual on-disk path for a project's Claude
+// conversation directory. It first tries the exact encoded name, then falls
+// back to a case-insensitive match against siblings under projectsRoot.
+//
+// The fallback handles Windows, where filepath.Abs may return the drive letter
+// in a different case than the one recorded when Claude Code originally created
+// the project folder (e.g. PowerShell yields "C:\..." while a VSCode-launched
+// session may have produced "c--..."). Returns the exact (possibly non-existent)
+// path if no match is found, so callers can still surface a useful error.
+func resolveProjectDir(projectsRoot, encoded string) string {
+	exact := filepath.Join(projectsRoot, encoded)
+	if _, err := os.Stat(exact); err == nil {
+		return exact
+	}
+	entries, err := os.ReadDir(projectsRoot)
+	if err != nil {
+		return exact
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.EqualFold(e.Name(), encoded) {
+			return filepath.Join(projectsRoot, e.Name())
+		}
+	}
+	return exact
 }
 
 func truncate(s string, maxLen int) string {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEncodeProjectPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple windows path",
+			in:   `C:\Users\alice`,
+			want: "C--Users-alice",
+		},
+		{
+			name: "underscore in path segment",
+			in:   `c:\Users\alice\dev\my_app\sub-dir`,
+			want: "c--Users-alice-dev-my-app-sub-dir",
+		},
+		{
+			name: "plus sign in path",
+			in:   `C:\src\a+b`,
+			want: "C--src-a-b",
+		},
+		{
+			name: "multiple underscores and plus together",
+			in:   `C:\src\foo_bar_baz+qux`,
+			want: "C--src-foo-bar-baz-qux",
+		},
+		{
+			name: "dot in path",
+			in:   `/Users/foo/my.project`,
+			want: "-Users-foo-my-project",
+		},
+		{
+			name: "space in path",
+			in:   `/Users/foo/my project`,
+			want: "-Users-foo-my-project",
+		},
+		{
+			name: "posix path",
+			in:   `/home/user/repo`,
+			want: "-home-user-repo",
+		},
+		{
+			// Non-ASCII (e.g. CJK) codepoints are dashed individually, matching
+			// Claude Code's `/[^a-zA-Z0-9]/g` regex over UTF-16 code units.
+			name: "non-ascii characters become dashes",
+			in:   `/home/user/文档/proj`,
+			want: "-home-user----proj",
+		},
+		{
+			// Misc punctuation — parentheses, brackets, ampersand, etc. all
+			// collapse to dashes just like the JS regex.
+			name: "punctuation collapses to dashes",
+			in:   `/tmp/foo (bar) [baz] & qux`,
+			want: "-tmp-foo--bar---baz----qux",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := encodeProjectPath(c.in)
+			if got != c.want {
+				t.Errorf("encodeProjectPath(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEncodeProjectPathLongPathHashSuffix(t *testing.T) {
+	// Mirror Claude Code's pM truncation: when the sanitized name exceeds 200
+	// chars, the result is the first 200 chars + "-" + base36(abs(hash))
+	// where hash is djb2-style over UTF-16 code units, 32-bit signed wraparound.
+	long := "/" + strings.Repeat("a", 250)
+	got := encodeProjectPath(long)
+
+	// Sanitized form: leading '-' then 250 'a's -> 251 chars. Should truncate
+	// to first 200, then '-', then a non-empty base36 hash.
+	if !strings.HasPrefix(got, "-"+strings.Repeat("a", 199)) {
+		t.Fatalf("unexpected prefix: %q", got[:min(len(got), 30)])
+	}
+	rest := got[200:]
+	if !strings.HasPrefix(rest, "-") {
+		t.Fatalf("expected '-' separator after first 200 chars, got %q", rest[:min(len(rest), 10)])
+	}
+	suffix := rest[1:]
+	if suffix == "" {
+		t.Fatal("expected non-empty hash suffix")
+	}
+	for _, r := range suffix {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'z')) {
+			t.Fatalf("hash suffix should be base36 alphanumeric, got %q", suffix)
+		}
+	}
+
+	// Distinct long inputs must produce distinct full keys (the whole point
+	// of the hash suffix — protect against collisions on truncation).
+	other := encodeProjectPath("/" + strings.Repeat("a", 249) + "b")
+	if other == got {
+		t.Fatalf("expected different keys for different long inputs, both = %q", got)
+	}
+}
+
+func TestResolveProjectDir(t *testing.T) {
+	root := t.TempDir()
+	// Folder created with a lowercase drive letter, mimicking what Claude
+	// Code stores when started from a session whose cwd reported the drive
+	// in lowercase (e.g. some VSCode launches on Windows).
+	actual := "c--Users-alice-dev-my-app"
+	if err := os.MkdirAll(filepath.Join(root, actual), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("exact match returns exact path", func(t *testing.T) {
+		got := resolveProjectDir(root, actual)
+		want := filepath.Join(root, actual)
+		if got != want {
+			t.Errorf("got %q; want %q", got, want)
+		}
+	})
+
+	t.Run("case-mismatched lookup resolves to an existing folder", func(t *testing.T) {
+		// What filepath.Abs may produce in PowerShell (uppercase drive) when
+		// the folder on disk was created with a lowercase drive letter.
+		requested := "C--Users-alice-dev-my-app"
+		got := resolveProjectDir(root, requested)
+		// On case-insensitive filesystems (Windows NTFS, macOS APFS default)
+		// the exact path stats successfully and is returned as-is. On
+		// case-sensitive filesystems (Linux ext4) the fallback returns the
+		// on-disk casing. Either is correct — both must open the same folder.
+		if _, err := os.Stat(got); err != nil {
+			t.Errorf("resolveProjectDir returned %q but it is not statable: %v", got, err)
+		}
+		// Also ensure that whichever casing was returned points to the same
+		// directory we created.
+		gotAbs, _ := filepath.EvalSymlinks(got)
+		wantAbs, _ := filepath.EvalSymlinks(filepath.Join(root, actual))
+		// On Windows EvalSymlinks normalises the case to the on-disk form.
+		// On case-sensitive FS the strings already match (fallback path).
+		if gotAbs == "" || wantAbs == "" || gotAbs != wantAbs {
+			t.Errorf("returned path %q does not resolve to created folder %q", gotAbs, wantAbs)
+		}
+	})
+
+	t.Run("no match returns exact (non-existent) path", func(t *testing.T) {
+		requested := "C--does-not-exist"
+		got := resolveProjectDir(root, requested)
+		want := filepath.Join(root, requested)
+		if got != want {
+			t.Errorf("got %q; want %q (should fall through to non-existent path)", got, want)
+		}
+	})
+
+	t.Run("missing projects root returns exact path", func(t *testing.T) {
+		missing := filepath.Join(root, "does-not-exist")
+		requested := "C--anything"
+		got := resolveProjectDir(missing, requested)
+		want := filepath.Join(missing, requested)
+		if got != want {
+			t.Errorf("got %q; want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`encodeProjectPath` doesn't match how Claude Code names project directories under `~/.claude/projects/`. The previous version of this PR special-cased `_` and `+`, but the underlying issue is broader — **any** character outside `[a-zA-Z0-9]` (Hangul, CJK, accented Latin, brackets, parens, ampersands, …) is collapsed to `-` by Claude Code, and a hand-rolled chain of `ReplaceAll` calls can never cover them all.

### Concrete reproduction (Windows, non-ASCII cwd)

```
cwd                : C:\Users\alice\OneDrive\文档\some project
cq encoded to      : C--Users-alice-OneDrive-文档-some-project       (← keeps non-ASCII as-is)
Claude Code folder : c--Users-alice-OneDrive----some-project         (← each non-ASCII codepoint becomes '-')
```

So `cq` reported looking in `…-文档-…` while the real folder on disk was `…----…`, and exited with "No conversations found for this project yet" even when conversations existed.

## Root cause (verified against the Claude Code binary)

Disassembling the bundled Claude Code (`~/.local/share/claude/versions/2.1.139`, a Bun executable) and grepping for the projects-dir construction reveals the actual function:

```js
function pM(H) {
  let q = H.replace(/[^a-zA-Z0-9]/g, "-");
  if (q.length <= 200) return q;
  return `${q.slice(0, 200)}-${Math.abs(hRH(H)).toString(36)}`;
}
function hRH(H) {                              // djb2-style hash
  let q = 0;
  for (let i = 0; i < H.length; i++)
    q = (q << 5) - q + H.charCodeAt(i) | 0;    // 32-bit signed wraparound
  return q;
}
```

The full rule has three pieces, all of which we now mirror:

1. **Single regex** `/[^a-zA-Z0-9]/g → '-'` per UTF-16 code unit (BMP chars contribute one dash; non-BMP surrogate pairs contribute two).
2. **Case is preserved** — drive-letter case differences (`C:\` from PowerShell vs `c:\` from some VSCode launches) are not normalized and produce different folder names. We keep `resolveProjectDir`'s case-insensitive disk-side fallback to bridge this.
3. **200-char truncation + base36 djb2-hash suffix** when the sanitized name would otherwise exceed 200 chars, so distinct long paths never collide after truncation.

## Fix

`encodeProjectPath` is rewritten as a single rune-loop replicating `pM` rune-for-rune:

```go
for _, r := range absPath {
    if alphanumericASCII(r) { b.WriteRune(r); continue }
    if r > 0xFFFF { b.WriteString(\"--\") } else { b.WriteByte('-') }
}
// then: truncate to 200 + \"-\" + base36(abs(djb2_int32(absPath)))
```

`resolveProjectDir` (case-insensitive on-disk fallback) is unchanged from the previous revision of this PR.

## Tests

`watcher_test.go` covers:

- `TestEncodeProjectPath`: simple windows path, underscore segment, `+`, mixed underscores+plus, dot, space, posix, non-ASCII (CJK), arbitrary punctuation.
- `TestEncodeProjectPathLongPathHashSuffix`: 200-char truncation, base36 alphanumeric suffix shape, and distinct full keys for two long inputs that differ only after the truncation cutoff.
- `TestResolveProjectDir`: exact match, case-mismatched lookup (verified via `filepath.EvalSymlinks`), missing folder fallback, missing root fallback.

All test data uses generic placeholders (`alice`, `my_app`, etc.) — no real machine paths.