### PR TITLE
fix: stop replaying historical events on JSONL switch + dedup by uuid

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -303,44 +303,96 @@ func (w *Watcher) tailFile() {
 			}
 
 			w.lastPos = info.Size()
+			// Refresh lastModTime so checkForNewerFile compares against the
+			// CURRENT file's freshest mtime — otherwise an externally-touched
+			// stale session file with mtime > our startup snapshot would always
+			// "win" the comparison and trigger a spurious switch.
+			w.lastModTime = info.ModTime()
 		}
 
 		file.Close()
 	}
 }
 
-// checkForNewerFile checks if a newer conversation file exists and switches to it
+// activeSessionWindow is how recently a candidate file must have been modified
+// to be considered a live session worth switching to. Claude Code occasionally
+// touches old session files for bookkeeping (mtime bump without growth);
+// requiring a recent mtime guards against switching to those stale files.
+const activeSessionWindow = 30 * time.Second
+
+// checkForNewerFile decides whether a different JSONL file under the project
+// directory has become the active session and, if so, switches to it. The
+// switch is intentionally conservative:
+//
+//  1. The candidate must have a strictly newer mtime than a FRESH stat of the
+//     current file (not the cached lastModTime, which may be stale between
+//     ticks).
+//  2. The candidate must look like a live session — UUID-shaped filename and
+//     mtime within activeSessionWindow of now.
+//
+// On switch, we seek to the END of the new file so we do NOT replay its
+// historical content as live events. (Without this, a 33MB-9k-event file
+// would dump all its prior events into the channel, inflating XP and showing
+// the user a flood of "same context replaying".)
 func (w *Watcher) checkForNewerFile() bool {
 	if w.ProjectDir == "" {
 		return false
 	}
 
 	filePath, modTime, err := w.findNewestConversation()
+	if err != nil || filePath == w.FilePath {
+		return false
+	}
+
+	// Compare against the CURRENT file's freshest mtime, not the stale
+	// w.lastModTime. If the active file is still being written, it is its
+	// own newest reference and we never switch away from it.
+	if curInfo, statErr := os.Stat(w.FilePath); statErr == nil {
+		if !modTime.After(curInfo.ModTime()) {
+			return false
+		}
+	} else if !modTime.After(w.lastModTime) {
+		// Current file vanished — fall back to the cached baseline.
+		return false
+	}
+
+	// Filter out spurious touches of historical sessions.
+	if !looksLikeActiveSession(filePath, modTime) {
+		return false
+	}
+
+	newInfo, err := os.Stat(filePath)
 	if err != nil {
 		return false
 	}
 
-	// If we found a different file that's newer, switch to it
-	if filePath != w.FilePath && modTime.After(w.lastModTime) {
-		oldFile := filepath.Base(w.FilePath)
-		newFile := filepath.Base(filePath)
+	oldFile := filepath.Base(w.FilePath)
+	newFile := filepath.Base(filePath)
 
-		w.FilePath = filePath
-		w.lastModTime = modTime
-		w.lastPos = 0 // Start from beginning of new file
+	w.FilePath = filePath
+	w.lastModTime = modTime
+	w.lastPos = newInfo.Size() // Seek to EOF — only emit events appended from now on.
 
-		// Notify about the switch
-		w.Events <- Event{
-			Type:    EventSystemInit,
-			Details: fmt.Sprintf("Switched: %s", newFile),
-		}
-
-		// Log the switch
-		fmt.Printf("Switched from %s to %s\n", oldFile, newFile)
-		return true
+	w.Events <- Event{
+		Type:    EventSystemInit,
+		Details: fmt.Sprintf("Switched: %s", newFile),
 	}
 
-	return false
+	fmt.Printf("Switched from %s to %s\n", oldFile, newFile)
+	return true
+}
+
+// looksLikeActiveSession reports whether a candidate file path appears to be a
+// live Claude Code session worth switching to. The filename must be UUID-shaped
+// (36 chars before .jsonl) and the supplied mtime must be within the active
+// window of "now", so that historical session files whose mtimes were merely
+// touched by Claude Code's bookkeeping are not eligible.
+func looksLikeActiveSession(path string, modTime time.Time) bool {
+	base := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if len(base) != 36 {
+		return false
+	}
+	return time.Since(modTime) <= activeSessionWindow
 }
 
 // StartReplay plays through an existing conversation file

--- a/watcher.go
+++ b/watcher.go
@@ -142,6 +142,7 @@ type Watcher struct {
 	ReplaySpeed time.Duration // Delay between events in replay mode
 	lastPos     int64         // Last read position for tailing
 	lastModTime time.Time     // Last modification time of current file
+	seenUUIDs   *uuidSet      // Bounded set of UUIDs already emitted, to drop replays
 
 	// State tracking
 	LastTokenUsage   *TokenUsage
@@ -155,6 +156,7 @@ func NewWatcher() *Watcher {
 		Events:           make(chan Event, 100),
 		ReplaySpeed:      200 * time.Millisecond, // Default replay speed
 		ActiveTaskAgents: make(map[string]string),
+		seenUUIDs:        newUUIDSet(50000),
 	}
 }
 
@@ -434,6 +436,25 @@ func (w *Watcher) StartReplay(filePath string) error {
 
 // parseLine parses a JSON line and returns events if applicable
 func (w *Watcher) parseLine(line string) []Event {
+	// Probe for an identity field first so we can drop duplicates without
+	// paying the full Unmarshal cost on lines we've already processed. Both
+	// "uuid" (regular messages) and "messageId" (file-history-snapshot rows)
+	// appear at the top level in Claude Code's JSONL.
+	var idProbe struct {
+		UUID      string `json:"uuid"`
+		MessageID string `json:"messageId"`
+	}
+	dedupKey := ""
+	if err := json.Unmarshal([]byte(line), &idProbe); err == nil {
+		dedupKey = idProbe.UUID
+		if dedupKey == "" {
+			dedupKey = idProbe.MessageID
+		}
+		if dedupKey != "" && w.seenUUIDs != nil && !w.seenUUIDs.add(dedupKey) {
+			return nil
+		}
+	}
+
 	var msg ClaudeMessage
 	if err := json.Unmarshal([]byte(line), &msg); err != nil {
 		return nil
@@ -461,6 +482,22 @@ func (w *Watcher) parseLine(line string) []Event {
 				Type:    EventIdle,
 				Details: truncate(msg.Summary, 50),
 			})
+		}
+	}
+
+	// Compact boundary marks a natural reset point: pre-compact UUIDs are no
+	// longer referenced by anything we'll process. Drop them so memory comes
+	// back early. The current line's own UUID is re-added so a hypothetical
+	// re-read of this exact line does not re-emit the compact event.
+	if w.seenUUIDs != nil {
+		for _, evt := range events {
+			if evt.Type == EventCompact {
+				w.seenUUIDs.reset()
+				if dedupKey != "" {
+					w.seenUUIDs.add(dedupKey)
+				}
+				break
+			}
 		}
 	}
 
@@ -824,6 +861,59 @@ func encodeProjectPath(absPath string) string {
 	encoded = strings.ReplaceAll(encoded, ".", "-")
 	encoded = strings.ReplaceAll(encoded, " ", "-")
 	return encoded
+}
+
+// uuidSet is a bounded set of UUIDs used by the watcher to drop events that
+// have already been emitted. Bounded means the oldest entries are evicted in
+// insertion order once capacity is reached — a ring buffer plus a map for O(1)
+// membership checks. 50k entries (≈5 MB) is more than enough headroom: a busy
+// JSONL holds a few thousand UUIDs, and we never need older history than a few
+// recent files.
+type uuidSet struct {
+	cap   int
+	order []string
+	head  int
+	full  bool
+	idx   map[string]struct{}
+}
+
+func newUUIDSet(capacity int) *uuidSet {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &uuidSet{
+		cap:   capacity,
+		order: make([]string, capacity),
+		idx:   make(map[string]struct{}, capacity),
+	}
+}
+
+// add records uuid in the set. Returns true if uuid was newly added (i.e. not
+// previously seen), false if it was already present.
+func (s *uuidSet) add(uuid string) bool {
+	if _, ok := s.idx[uuid]; ok {
+		return false
+	}
+	if s.full {
+		delete(s.idx, s.order[s.head])
+	}
+	s.order[s.head] = uuid
+	s.idx[uuid] = struct{}{}
+	s.head++
+	if s.head == s.cap {
+		s.head = 0
+		s.full = true
+	}
+	return true
+}
+
+// reset clears all remembered UUIDs. Used at conversation boundaries such as
+// compact, where pre-boundary message UUIDs are no longer interesting and
+// memory can be freed back early.
+func (s *uuidSet) reset() {
+	s.idx = make(map[string]struct{}, s.cap)
+	s.head = 0
+	s.full = false
 }
 
 func truncate(s string, maxLen int) string {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -114,6 +114,98 @@ func TestCheckForNewerFile_NonUUIDFilenameIgnored(t *testing.T) {
 	}
 }
 
+func TestUUIDSet_AddIsDedup(t *testing.T) {
+	s := newUUIDSet(16)
+	if !s.add("a") {
+		t.Fatalf("first add of 'a' should return true (newly added)")
+	}
+	if s.add("a") {
+		t.Fatalf("second add of 'a' should return false (already present)")
+	}
+	if !s.add("b") {
+		t.Fatalf("first add of 'b' should return true")
+	}
+}
+
+func TestUUIDSet_EvictsOldestAtCapacity(t *testing.T) {
+	const cap = 4
+	s := newUUIDSet(cap)
+	for i := 0; i < cap; i++ {
+		if !s.add(fmt.Sprintf("u%d", i)) {
+			t.Fatalf("fresh add returned false at i=%d", i)
+		}
+	}
+	// All cap distinct keys present — re-adding "u0" should still be a dup.
+	if s.add("u0") {
+		t.Fatalf("u0 should still be present before any evictions")
+	}
+	// Adding a new key forces eviction of the oldest ("u0").
+	if !s.add("u4") {
+		t.Fatalf("u4 should be a fresh add")
+	}
+	// Now "u0" must be evictable — re-adding returns true.
+	if !s.add("u0") {
+		t.Fatalf("u0 should have been evicted and now count as newly added")
+	}
+}
+
+func TestUUIDSet_ResetClearsAll(t *testing.T) {
+	s := newUUIDSet(8)
+	for i := 0; i < 5; i++ {
+		s.add(fmt.Sprintf("u%d", i))
+	}
+	s.reset()
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("u%d", i)
+		if !s.add(key) {
+			t.Fatalf("after reset, %q should be a fresh add", key)
+		}
+	}
+}
+
+func TestParseLine_DedupesByUUID(t *testing.T) {
+	w := NewWatcher()
+	line := `{"type":"assistant","uuid":"abc-123","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}`
+
+	first := w.parseLine(line)
+	if len(first) == 0 {
+		t.Fatalf("first parseLine should emit at least one event")
+	}
+	second := w.parseLine(line)
+	if len(second) != 0 {
+		t.Fatalf("second parseLine should be deduped to zero events, got %d", len(second))
+	}
+}
+
+func TestParseLine_CompactResetsDedupSet(t *testing.T) {
+	// After a compact boundary, pre-compact UUIDs are no longer referenced
+	// by anything we'll process. The dedup set should reset so memory is
+	// freed early, while still preserving the compact line's own UUID so
+	// re-reading that exact line cannot re-emit the compact event.
+	w := NewWatcher()
+
+	pre := `{"type":"assistant","uuid":"pre-1","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`
+	compact := `{"type":"system","subtype":"compact_boundary","uuid":"compact-1","compactMetadata":{"trigger":"auto","preTokens":120000}}`
+
+	if got := w.parseLine(pre); len(got) == 0 {
+		t.Fatalf("expected pre-compact event")
+	}
+	if got := w.parseLine(compact); len(got) == 0 || got[0].Type != EventCompact {
+		t.Fatalf("expected compact event")
+	}
+
+	// Pre-compact UUID should now count as fresh again — reset cleared it.
+	if got := w.parseLine(pre); len(got) == 0 {
+		t.Fatalf("pre-compact UUID should be acceptable after compact reset, got nothing")
+	}
+
+	// But the compact line itself was re-added after reset, so re-reading
+	// the compact line is still deduped.
+	if got := w.parseLine(compact); len(got) != 0 {
+		t.Fatalf("compact line should remain deduped after reset, got %d events", len(got))
+	}
+}
+
 func TestCheckForNewerFile_RealSessionSwitchSeeksToEOF(t *testing.T) {
 	dir := t.TempDir()
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeJSONL creates a JSONL file with the given lines and forces its mtime
+// to the supplied value via os.Chtimes (newer than the previous mtime by the
+// caller's choice).
+func writeJSONL(t *testing.T, dir, name string, lines []string, mtime time.Time) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	if err := os.Chtimes(p, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", p, err)
+	}
+	return p
+}
+
+func newWatcherFor(dir string) *Watcher {
+	w := NewWatcher()
+	w.ProjectDir = dir
+	return w
+}
+
+// uuidName returns a 36-character UUID-shaped filename stem with .jsonl suffix.
+func uuidName(n int) string {
+	return fmt.Sprintf("%08d-1111-2222-3333-%012d.jsonl", n, n)
+}
+
+func TestCheckForNewerFile_ActiveFileNotSwitchedAway(t *testing.T) {
+	dir := t.TempDir()
+
+	now := time.Now()
+	active := writeJSONL(t, dir, uuidName(1), []string{`{"uuid":"u-active-1","type":"user"}`}, now)
+	// A second file that's slightly OLDER than the active one — must not
+	// "win" the comparison even though both exist.
+	_ = writeJSONL(t, dir, uuidName(2), []string{`{"uuid":"u-other-1","type":"user"}`}, now.Add(-2*time.Second))
+
+	w := newWatcherFor(dir)
+	w.FilePath = active
+	w.lastModTime = now
+	if w.checkForNewerFile() {
+		t.Fatalf("checkForNewerFile switched even though active file is newest")
+	}
+	if filepath.Base(w.FilePath) != filepath.Base(active) {
+		t.Fatalf("FilePath changed unexpectedly: %s", w.FilePath)
+	}
+}
+
+func TestCheckForNewerFile_StaleBaselineDoesNotTriggerSwitch(t *testing.T) {
+	// Regression: previously, lastModTime froze at startup and any other
+	// file whose mtime exceeded that frozen value would cause a switch —
+	// even if the active file was *currently* even newer.
+	dir := t.TempDir()
+
+	now := time.Now()
+	active := writeJSONL(t, dir, uuidName(1), []string{`{"uuid":"u-active-1"}`}, now)
+	_ = writeJSONL(t, dir, uuidName(2), []string{`{"uuid":"u-other-1"}`}, now.Add(-1*time.Second))
+
+	w := newWatcherFor(dir)
+	w.FilePath = active
+	// Pretend baseline is way in the past (simulating tailFile having not
+	// refreshed it yet). The fix uses a fresh stat of FilePath instead.
+	w.lastModTime = now.Add(-1 * time.Hour)
+	if w.checkForNewerFile() {
+		t.Fatalf("switched on stale baseline; fix should compare against fresh stat")
+	}
+}
+
+func TestCheckForNewerFile_TouchedHistoricalFileIgnored(t *testing.T) {
+	// Claude Code occasionally touches old session files. Even if such a
+	// file becomes "newest" by mtime, we should not switch to it because
+	// it isn't a live session — its mtime is older than activeSessionWindow.
+	dir := t.TempDir()
+
+	stale := time.Now().Add(-(activeSessionWindow + time.Minute))
+	active := writeJSONL(t, dir, uuidName(1), []string{`{"uuid":"u-1"}`}, stale.Add(-time.Hour))
+	// "Touched" historical file: UUID-shaped name, newer than active, but
+	// mtime itself is well outside the active-session window.
+	_ = writeJSONL(t, dir, uuidName(2), []string{`{"uuid":"u-2"}`}, stale)
+
+	w := newWatcherFor(dir)
+	w.FilePath = active
+	w.lastModTime = stale.Add(-time.Hour)
+	if w.checkForNewerFile() {
+		t.Fatalf("switched to a historical file whose mtime was outside the active-session window")
+	}
+}
+
+func TestCheckForNewerFile_NonUUIDFilenameIgnored(t *testing.T) {
+	dir := t.TempDir()
+
+	now := time.Now()
+	active := writeJSONL(t, dir, uuidName(1), []string{`{"uuid":"u-1"}`}, now.Add(-1*time.Second))
+	// A non-UUID-shaped filename — must not be considered a live session.
+	_ = writeJSONL(t, dir, "scratch.jsonl", []string{`{"uuid":"u-2"}`}, now)
+
+	w := newWatcherFor(dir)
+	w.FilePath = active
+	w.lastModTime = now.Add(-1 * time.Second)
+	if w.checkForNewerFile() {
+		t.Fatalf("switched to a non-UUID-shaped file")
+	}
+}
+
+func TestCheckForNewerFile_RealSessionSwitchSeeksToEOF(t *testing.T) {
+	dir := t.TempDir()
+
+	now := time.Now()
+	active := writeJSONL(t, dir, uuidName(1), []string{`{"uuid":"u-old-1"}`}, now.Add(-5*time.Second))
+
+	// New live session: UUID-shaped, mtime is now, contains ten lines of
+	// historical content that MUST NOT be replayed after the switch.
+	historicalLines := make([]string, 10)
+	for i := range historicalLines {
+		historicalLines[i] = fmt.Sprintf(`{"uuid":"u-new-%d","type":"user"}`, i)
+	}
+	newSession := writeJSONL(t, dir, uuidName(2), historicalLines, now)
+
+	w := newWatcherFor(dir)
+	w.FilePath = active
+	w.lastModTime = now.Add(-5 * time.Second)
+	w.lastPos = 999 // a meaningless previous position
+
+	if !w.checkForNewerFile() {
+		t.Fatalf("expected switch to genuinely newer session file")
+	}
+	if w.FilePath != newSession {
+		t.Fatalf("FilePath = %s; want %s", w.FilePath, newSession)
+	}
+	info, err := os.Stat(newSession)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if w.lastPos != info.Size() {
+		t.Fatalf("lastPos = %d; want EOF (%d) so historical lines are skipped",
+			w.lastPos, info.Size())
+	}
+}


### PR DESCRIPTION
## Problem

Reported by a user running `cq --korean` against `~/.claude/projects/<encoded-cwd>/*.jsonl`: after `cq` printed

```
Switched from <session-A>.jsonl to <session-B>.jsonl
```

the same conversation context started replaying through the watcher repeatedly and XP began climbing without any real user action behind it.

## Root cause

Two compounding watcher bugs in [watcher.go](watcher.go):

### 1. Stale baseline for the "switch to newer file" decision

`checkForNewerFile()` decided whether to switch by comparing the candidate's mtime against `w.lastModTime`, which was set **once** in `FindProjectConversation` and only refreshed on a *prior* switch — never while actively tailing. The active file could grow for hours while `lastModTime` stayed at its startup snapshot, so any other session file whose mtime exceeded that frozen value (including stale historical sessions that Claude Code occasionally touches for bookkeeping) trivially won the comparison.

### 2. Offset-zero re-read of the switched-to file

On switch, `w.lastPos = 0` was unconditionally set, then `tailFile()`'s next tick `Seek(0, SeekStart)` and parsed the entire history of the new file. In the reported scenario the switched-to file was 33MB / ~9,500 events — every one of which streamed back through the event channel and was treated as a fresh live action by [main.go](main.go)'s `HandleEvent`, granting XP through `Profile.RecordRead/Write/Bash/Thinking/AgentComplete/...`.

There is no event deduplication anywhere downstream, so once the replay started there was nothing to stop the XP from compounding until the switch eventually settled.

## Fix

Split into two reviewable commits.

### `fix: stop replaying historical events on JSONL session switch`

- `tailFile()` now refreshes `w.lastModTime = info.ModTime()` after every successful read of the current file. The watcher's idea of "what mtime is the active file at" stays current instead of frozen.
- `checkForNewerFile()` compares the candidate's mtime against a **fresh `os.Stat` of the current file**, not against the cached baseline. An actively-growing session is its own freshest reference and cannot be lost to a one-off external touch.
- A new `looksLikeActiveSession` guard rejects candidates whose filename isn't UUID-shaped or whose mtime is older than 30s. Old historical sessions whose mtimes were merely touched (no real activity) no longer pass.
- On a real switch, `w.lastPos = newInfo.Size()` — seek to EOF rather than offset 0, so only events appended **after** the switch are emitted.

### `feat: dedup events by uuid with compact-aware reset`

Defense-in-depth, so a future regression in the file-switching logic (or any other path that re-parses lines) cannot recreate the XP-replay symptom.

- Watcher gets a `seenUUIDs *uuidSet` field: a ring-buffer-backed bounded set (50k entries, ~5 MB hard ceiling, oldest entries auto-evicted).
- `parseLine()` cheaply probes each line for `uuid` or `messageId` and drops the line on a hit.
- On `compact_boundary`, the set is reset (the compact line's own UUID is re-added so re-reading that line still no-ops). I confirmed against real session JSONLs that all post-compact rows have new UUIDs with `parentUuid` chaining back to the compact marker — so pre-compact UUIDs are genuinely orphan and the reset only frees memory at a semantically clean boundary.

## Tests

`watcher_test.go` (new file):

- `TestCheckForNewerFile_ActiveFileNotSwitchedAway` — active file is its own newest reference; no switch.
- `TestCheckForNewerFile_StaleBaselineDoesNotTriggerSwitch` — regression guard for the exact bug.
- `TestCheckForNewerFile_TouchedHistoricalFileIgnored` — historical session whose mtime got touched but is outside the active window is not eligible.
- `TestCheckForNewerFile_NonUUIDFilenameIgnored` — non-session files don't pass `looksLikeActiveSession`.
- `TestCheckForNewerFile_RealSessionSwitchSeeksToEOF` — a genuinely newer live session triggers a switch **and** `lastPos` lands at EOF, so the 10 pre-existing lines do not stream back as events.
- `TestUUIDSet_AddIsDedup`, `TestUUIDSet_EvictsOldestAtCapacity`, `TestUUIDSet_ResetClearsAll` — bounded-set semantics.
- `TestParseLine_DedupesByUUID` — same JSON line returns events first, nil second.
- `TestParseLine_CompactResetsDedupSet` — compact frees pre-compact UUIDs while keeping the compact line itself deduped.

`go test -c` builds cleanly. (Full `go test` requires raylib's DLL on PATH, which my CI doesn't have — I verified each behavior in addition with standalone harness programs that vendored the affected functions.)