### PR TITLE
fix: align picker position counter with the items-list filter

### DIFF
--- a/renderer_picker_modal.go
+++ b/renderer_picker_modal.go
@@ -64,7 +64,19 @@ func (r *Renderer) IsModalPickerOpen() bool {
 	return r.pickerModal
 }
 
-// syncItemIndices sets the picker item indices to match current equipped items
+// syncItemIndices sets the picker item indices to match current equipped items.
+//
+// The picker UI builds its slot lists from owned items that are ALSO present
+// in the renderer's `names` array (i.e. whose texture/swatch was successfully
+// loaded). cycleSlotItem and getSlotItemInfo both apply this "in names" filter
+// when constructing their lists, and pickerItemIndex addresses into those
+// lists. syncItemIndices must apply the same filter when counting, otherwise
+// an owned-but-unloaded item (e.g. an accessory whose PNG is missing from a
+// packaged npm asset bundle) shifts every following position by one — which
+// for the last item in ItemRegistry causes the index to go out of bounds,
+// and getSlotItemInfo silently falls back to slot 0 ("none"). Symptom: after
+// equipping the highest-level item and closing/reopening the picker, the
+// slot displays as empty.
 func (r *Renderer) syncItemIndices() {
 	slotTypes := []ItemSlot{SlotHat, SlotFace, SlotAura, SlotTrail}
 	currentIdxs := []int{r.currentHat, r.currentFace, r.currentAura, r.currentTrail}
@@ -80,24 +92,36 @@ func (r *Renderer) syncItemIndices() {
 			currentID = names[currentIdx]
 		}
 
-		pos := 0
 		if currentID == "" {
 			r.pickerItemIndex[slot] = 0
 			continue
 		}
 
+		nameSet := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			nameSet[n] = struct{}{}
+		}
+
+		pos := 0
 		idx := 1 // Start after "none"
 		for _, item := range ItemRegistry {
-			if item.Slot == slotType {
-				isOwned := r.profile != nil && r.profile.IsOwned(item.ID)
-				if isOwned {
-					if item.ID == currentID {
-						pos = idx
-						break
-					}
-					idx++
-				}
+			if item.Slot != slotType {
+				continue
 			}
+			if r.profile != nil && !r.profile.IsOwned(item.ID) {
+				continue
+			}
+			if _, loaded := nameSet[item.ID]; !loaded {
+				// Same filter as cycleSlotItem / getSlotItemInfo: skip items
+				// whose texture isn't available, so position counting stays
+				// aligned across all three call sites.
+				continue
+			}
+			if item.ID == currentID {
+				pos = idx
+				break
+			}
+			idx++
 		}
 		r.pickerItemIndex[slot] = pos
 	}

--- a/renderer_picker_modal_test.go
+++ b/renderer_picker_modal_test.go
@@ -1,0 +1,196 @@
+package main
+
+import "testing"
+
+// newPickerTestRenderer builds a minimal Renderer suitable for exercising
+// syncItemIndices without touching raylib resources. The texture slices are
+// left empty — only the *Names slices are inspected by the function under
+// test.
+func newPickerTestRenderer(profile *CareerProfile, hatNames, faceNames, auraNames, trailNames []string) *Renderer {
+	return &Renderer{
+		profile:      profile,
+		hatNames:     hatNames,
+		faceNames:    faceNames,
+		auraNames:    auraNames,
+		trailNames:   trailNames,
+		currentHat:   -1,
+		currentFace:  -1,
+		currentAura:  -1,
+		currentTrail: -1,
+	}
+}
+
+// loadedHatNamesMissingOne returns the full hat-id list from ItemRegistry
+// with one id removed, simulating a packaged asset bundle whose .png for
+// that id is missing on disk so loadHats never populated it into hatNames.
+func loadedHatNamesMissingOne(missingID string) []string {
+	var names []string
+	for _, item := range ItemRegistry {
+		if item.Slot != SlotHat {
+			continue
+		}
+		if item.ID == missingID {
+			continue
+		}
+		names = append(names, item.ID)
+	}
+	return names
+}
+
+// allOwnedProfile returns a profile that owns every item in ItemRegistry.
+func allOwnedProfile() *CareerProfile {
+	p := &CareerProfile{OwnedItems: map[string]bool{}}
+	for _, item := range ItemRegistry {
+		p.OwnedItems[item.ID] = true
+	}
+	return p
+}
+
+// findItemIDAfter returns the id of the first hat in ItemRegistry that
+// appears AFTER the supplied id. Useful for picking a known "shifted"
+// target in drift tests.
+func findItemIDAfter(after string) string {
+	seen := false
+	for _, item := range ItemRegistry {
+		if item.Slot != SlotHat {
+			continue
+		}
+		if seen {
+			return item.ID
+		}
+		if item.ID == after {
+			seen = true
+		}
+	}
+	return ""
+}
+
+// pickerPositionInLoadedList computes the expected pickerItemIndex value for
+// the supplied hat id, mirroring exactly how cycleSlotItem/getSlotItemInfo
+// build their items list: 0 = "none", then owned-and-loaded items in
+// ItemRegistry order. syncItemIndices must agree with this counting.
+func pickerPositionInLoadedList(id string, names []string, profile *CareerProfile) int {
+	loaded := map[string]struct{}{}
+	for _, n := range names {
+		loaded[n] = struct{}{}
+	}
+	idx := 1
+	for _, item := range ItemRegistry {
+		if item.Slot != SlotHat {
+			continue
+		}
+		if !profile.IsOwned(item.ID) {
+			continue
+		}
+		if _, ok := loaded[item.ID]; !ok {
+			continue
+		}
+		if item.ID == id {
+			return idx
+		}
+		idx++
+	}
+	return 0
+}
+
+// indexOf returns the position of id in names, or -1.
+func indexOf(names []string, id string) int {
+	for i, n := range names {
+		if n == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestSyncItemIndices_HappyPathAllLoaded(t *testing.T) {
+	// No drift: every owned hat is also loaded. pickerItemIndex must match
+	// the position in cycleSlotItem's items list (none + loaded-owned).
+	profile := allOwnedProfile()
+	hatNames := loadedHatNamesMissingOne("") // remove nothing — all loaded
+	r := newPickerTestRenderer(profile, hatNames, nil, nil, nil)
+
+	// Pick a mid-list hat and the last hat; both must yield matching positions.
+	cases := []string{hatNames[0], hatNames[len(hatNames)/2], hatNames[len(hatNames)-1]}
+	for _, id := range cases {
+		r.currentHat = indexOf(hatNames, id)
+		r.syncItemIndices()
+		want := pickerPositionInLoadedList(id, hatNames, profile)
+		if got := r.pickerItemIndex[0]; got != want {
+			t.Errorf("hat %q: pickerItemIndex[0] = %d; want %d (happy path, no drift)", id, got, want)
+		}
+	}
+}
+
+func TestSyncItemIndices_DriftBetweenRegistryAndLoadedNames(t *testing.T) {
+	// Simulate an asset/registry drift where one hat is in ItemRegistry and
+	// owned by the profile but absent from hatNames (e.g. its .png wasn't
+	// shipped with this build). Every hat in ItemRegistry that comes AFTER
+	// the missing one should still resolve to its correct visible position,
+	// and the LAST registry hat must not land out of bounds.
+	const dropped = "zeus" // hat that exists in ItemRegistry mid-list
+
+	profile := allOwnedProfile()
+	hatNames := loadedHatNamesMissingOne(dropped)
+	r := newPickerTestRenderer(profile, hatNames, nil, nil, nil)
+
+	// Sanity: hat directly after the dropped one must NOT share its position
+	// with anything else. The bug was off-by-one for this hat, and out-of-
+	// bounds for the final hat.
+	afterDropped := findItemIDAfter(dropped)
+	if afterDropped == "" {
+		t.Fatalf("test fixture: no hat appears after %q in ItemRegistry", dropped)
+	}
+
+	cases := []string{afterDropped, hatNames[len(hatNames)-1]}
+	for _, id := range cases {
+		r.currentHat = indexOf(hatNames, id)
+		if r.currentHat < 0 {
+			t.Fatalf("test fixture: %q not present in loaded hatNames", id)
+		}
+		r.syncItemIndices()
+		want := pickerPositionInLoadedList(id, hatNames, profile)
+		if got := r.pickerItemIndex[0]; got != want {
+			t.Errorf("hat %q: pickerItemIndex[0] = %d; want %d (drift case — %q missing from hatNames)",
+				id, got, want, dropped)
+		}
+	}
+}
+
+func TestSyncItemIndices_UnownedItemsNotCounted(t *testing.T) {
+	// Items the profile does not own must never advance the position counter,
+	// regardless of whether they would be loaded.
+	profile := &CareerProfile{OwnedItems: map[string]bool{}}
+	hatNames := loadedHatNamesMissingOne("")
+
+	// Own only the last hat in ItemRegistry. Pickers expect position 1 (just
+	// after "none") because it is the sole owned-loaded entry.
+	var lastHat string
+	for _, item := range ItemRegistry {
+		if item.Slot == SlotHat {
+			lastHat = item.ID
+		}
+	}
+	profile.OwnedItems[lastHat] = true
+
+	r := newPickerTestRenderer(profile, hatNames, nil, nil, nil)
+	r.currentHat = indexOf(hatNames, lastHat)
+
+	r.syncItemIndices()
+	if got := r.pickerItemIndex[0]; got != 1 {
+		t.Errorf("solitary owned hat at end of registry: pickerItemIndex[0] = %d; want 1", got)
+	}
+}
+
+func TestSyncItemIndices_NoCurrentItemResetsToNone(t *testing.T) {
+	// currentHat = -1 (no hat equipped) must always land on position 0.
+	profile := allOwnedProfile()
+	hatNames := loadedHatNamesMissingOne("")
+	r := newPickerTestRenderer(profile, hatNames, nil, nil, nil)
+	r.pickerItemIndex[0] = 5 // stale value — must be overwritten
+
+	r.syncItemIndices()
+	if got := r.pickerItemIndex[0]; got != 0 {
+		t.Errorf("currentHat=-1: pickerItemIndex[0] = %d; want 0", got)
+	}
+}


### PR DESCRIPTION
## Potential issue

The modal accessory picker has three functions that each construct or address into the same logical \"items list\" for a slot — `[none, owned-and-loaded items in ItemRegistry order, unowned items]`:

| Function | Role | \"Loaded\" filter applied? |
|---|---|---|
| [`cycleSlotItem`](renderer_picker_modal.go) | builds list on arrow nav | yes (`idx >= 0` in `hatNames` / `faceNames` / etc.) |
| [`getSlotItemInfo`](renderer_picker_modal.go) | reads list each draw | yes (same lookup) |
| [`syncItemIndices`](renderer_picker_modal.go) | restores cursor on open | **no** — counts every owned item from `ItemRegistry` |

When the two sets disagree — that is, the profile owns an item whose id is in `ItemRegistry` but **not** in the renderer's loaded `*Names` slice — `syncItemIndices` advances `idx` for it while `cycleSlotItem` and `getSlotItemInfo` do not. The picker cursor lands one position past where the item actually appears in the visible list.

Concrete consequences for `SlotHat` with one mid-registry hat missing from `hatNames`:

- Every hat that appears AFTER the missing one in `ItemRegistry` is rendered as the NEXT hat in the items list (off-by-one).
- The LAST hat in `ItemRegistry` yields `pickerItemIndex[slot] == len(items)`, which trips `getSlotItemInfo`'s defensive `pos >= len(items)` guard and silently falls back to position 0 (\"none\").

The visible symptom is: after equipping a high-registry-position accessory and closing/reopening the picker, the slot displays as empty.

## When can the drift happen?

Any time `ItemRegistry` and the renderer's `*Names` slice diverge. Examples:

- A packaged asset bundle that omits a `.png` (e.g. an older release whose asset list lagged behind a new `ItemRegistry` entry).
- A runtime texture-load failure for one accessory (permission error on a specific file, partial download, …).
- A future `ItemRegistry` entry added in code before its asset is committed.

In each case, the current code drops the equipped accessory's visual state on the next picker open, which is hard to attribute and easy to misread as a save/load bug.

## Fix

Add the same \"loaded\" filter to `syncItemIndices` so all three functions agree on counting. The filter is a single `nameSet` lookup and short-circuits identically to the existing two call sites.

```go
nameSet := make(map[string]struct{}, len(names))
for _, n := range names { nameSet[n] = struct{}{} }

for _, item := range ItemRegistry {
    if item.Slot != slotType { continue }
    if r.profile != nil && !r.profile.IsOwned(item.ID) { continue }
    if _, loaded := nameSet[item.ID]; !loaded { continue }  // ← added
    if item.ID == currentID { pos = idx; break }
    idx++
}
```

No change for the happy path (all owned items also loaded) — `nameSet` lookup is true for every owned item, so position counting is identical to before.

## Tests

`renderer_picker_modal_test.go` (new file) constructs a minimal `Renderer` (no raylib resources touched) and verifies:

- **Happy path** — all hats loaded; mid-list and last hat both resolve to the position that the items-list builder would produce.
- **Drift case** — one mid-registry hat removed from `hatNames` while the profile still owns it. Every hat after the missing one (and the last hat in particular) resolves to its correct visible position, no longer overshooting.
- **Unowned items not counted** — profile owns only the last hat in `ItemRegistry`; cursor must land at position 1 (just after \"none\"), not advance for unowned earlier items.
- **No equipment → position 0** — `currentHat == -1` clears any stale `pickerItemIndex` value.

Tests compile cleanly; full `go test` requires raylib's DLL on PATH (package init loads it), which the project's CI provides.